### PR TITLE
node fs exception code emulation

### DIFF
--- a/lib/common.js
+++ b/lib/common.js
@@ -1,23 +1,33 @@
 module.exports = {
-   /**
-    *
-    * @returns {Function}
-    */
-   wrapSyncCall: function(method){
-      return function() {
-         var cb = this._getcb(arguments),
-             args = Array.prototype.slice.call(arguments),
-             call;
+    /**
+     *
+     * @returns {Function}
+     */
+    wrapSyncCall: function (method) {
+        return function () {
+            var cb = this._getcb(arguments),
+                args = Array.prototype.slice.call(arguments),
+                call;
 
-         args.unshift(this);
-         call = Function.prototype.bind.apply(this[method], args);
-         process.nextTick(function(){
-            try {
-               cb(null, call());
-            } catch(e) {
-               cb(e);
-            }
-         });
-      }
-   }
+            args.unshift(this);
+            call = Function.prototype.bind.apply(this[method], args);
+            process.nextTick(function () {
+                try {
+                    cb(null, call());
+                } catch (e) {
+                    cb(e);
+                }
+            });
+        };
+    },
+    /**
+     * @returns {Error} exception type Error, decorated with errno, code and syscall - as found in node fs
+     */
+    errNoException: function (errno, syscall) {
+        var exception = new Error(errno,syscall);
+        exception.code=exception.errno=errno;
+        exception.syscall = syscall;
+        return exception;
+    }
+
 };

--- a/lib/fd-manager.js
+++ b/lib/fd-manager.js
@@ -1,4 +1,5 @@
 (function(){
+   'use strict';
    var errNoException = require('./common.js').errNoException;
    var pool = [];
 

--- a/lib/fd-manager.js
+++ b/lib/fd-manager.js
@@ -1,7 +1,5 @@
 (function(){
-
-   "use strict";
-
+   var errNoException = require('./common.js').errNoException;
    var pool = [];
 
    for(var i = 0; i < 255; i++) {
@@ -18,20 +16,20 @@
       getFd: function() {
          if(pool.length === 0) {
             // too many open files
-            throw new Error('EMFILE');
+            throw errNoException('EMFILE','getFD');
          }
          return pool.pop();
       },
       releaseFd: function() {
          Array.prototype.push.apply(pool, arguments);
          if(pool.length > 255) {
-            throw new Error('EINSANITY');
+            throw errNoException('EINSANITY','releaseFd');
          }
       },
       isSane: function() {
          return pool.length == 255;
       }
-   }
+   };
 
 
 })();

--- a/lib/fd-manager.js
+++ b/lib/fd-manager.js
@@ -1,5 +1,5 @@
 (function(){
-   'use strict';
+   "use strict";
    var errNoException = require('./common.js').errNoException;
    var pool = [];
 

--- a/lib/mockfs.js
+++ b/lib/mockfs.js
@@ -3,199 +3,199 @@ var fs = require('fs'),
     wrap = require('./wrapfs.js'),
     fdmgr = require('./fd-manager.js'),
     Stats = require('./stat.js'),
-    nop = function() {},
+    nop = function () {},
     mountPoints = {},
-    plugins = [ 'chown', 'exists', 'fd', 'mkdir', 'readdir', 'rename', 'rmdir', 'stat', 'unlink', 'utimes' ];
+    plugins = ['chown', 'exists', 'fd', 'mkdir', 'readdir', 'rename', 'rmdir', 'stat', 'unlink', 'utimes'],
+    errNoException = require('./common.js').errNoException;
 
 // Tessel support
 if (process.platform == 'colony') {
-   plugins.push('readfile', 'writefile', 'appendfile');
+    plugins.push('readfile', 'writefile', 'appendfile');
 }
 
 wrap(fs, mountPoints);
 
-(function(){
+(function () {
 
-   "use strict";
+    function MockFS(spec) {
+        var now = new Date();
+        this._mounted = false;
+        this._path = null;
+        this._spec = spec;
+        this._atime = spec.atime || spec.time || now;
+        this._ctime = spec.ctime || spec.time || now;
+        this._mtime = spec.mtime || spec.time || now;
+        this._options = {};
+        this._fdManager = fdmgr;
+        this._fds = [];
+    }
 
-   function MockFS(spec) {
-      var now = new Date();
-      this._mounted = false;
-      this._path = null;
-      this._spec = spec;
-      this._atime = spec.atime || spec.time || now;
-      this._ctime = spec.ctime || spec.time || now;
-      this._mtime = spec.mtime || spec.time || now;
-      this._options = {};
-      this._fdManager = fdmgr;
-      this._fds = [];
-   }
-
-   MockFS.prototype._throwIfNotString = function() {
-      for(var i = 0, l = arguments.length; i < l; i++) {
-         if(typeof arguments[i] !== 'string') {
-            throw new TypeError("path must be a string");
-         }
-      }
-   };
-
-   MockFS.prototype._throwIfNotNumber = function() {
-      for(var i = 0, l = arguments.length; i < l; i++) {
-         if(typeof arguments[i] !== 'number') {
-            throw new TypeError("bad argument");
-         }
-      }
-   };
-
-   MockFS.prototype._throwIfFSReadOnly = function() {
-      if(this._options.readonly) {
-         throw new Error('EROFS');
-      }
-   };
-
-   MockFS.prototype._getFd = function() {
-      var fd = this._fdManager.getFd();
-      this._fds.push(fd);
-      return fd;
-   };
-
-   MockFS.prototype._releaseFd = function(fd) {
-      this._fdManager.releaseFd(fd);
-      this._fds.splice(this._fds.indexOf(fd), 1);
-   };
-
-   MockFS.prototype.hasFd = function(fd) {
-      return this._fds.indexOf(fd) !== -1;
-   };
-
-   MockFS.prototype._removeFSItem = function(p) {
-      this._throwIfFSReadOnly();
-      var parent = this._lookupParent(p);
-      delete parent.items[path.basename(p)];
-   };
-
-   MockFS.prototype._getcb = function (args) {
-      for(var i = args.length; i >= 0; i--) {
-         if(typeof args[i] == 'function') {
-            var f = args[i];
-            delete args[i];
-            return f;
-         }
-      }
-      return nop;
-   };
-
-   MockFS.prototype._resolveAndRelate = function(p) {
-      return path.resolve(p).substr(this._path.length);
-   };
-
-   MockFS.prototype._lookup = function(p) {
-      var root = this._spec, pathItem;
-
-      this._throwIfNotString(p);
-
-      p = this._resolveAndRelate(p).split(path.sep);
-      while(p.length) {
-         pathItem = p.shift();
-         if(pathItem) {
-            if(root && root.items && pathItem in root.items) {
-               root = root.items[pathItem]
-            } else {
-               throw new Error('ENOENT');
+    MockFS.prototype._throwIfNotString = function () {
+        for (var i = 0, l = arguments.length; i < l; i++) {
+            if (typeof arguments[i] !== 'string') {
+                throw new TypeError("path must be a string");
             }
-         }
-      }
-      return root;
-   };
+        }
+    };
 
-   MockFS.prototype._createBuffer = function(data, encoding) {
-      return Buffer.isBuffer(data) ? data : new Buffer(data, encoding || 'utf8');
-   };
+    MockFS.prototype._throwIfNotNumber = function () {
+        for (var i = 0, l = arguments.length; i < l; i++) {
+            if (typeof arguments[i] !== 'number') {
+                throw new TypeError("bad argument");
+            }
+        }
+    };
 
-   MockFS.prototype._lookupParent = function(p) {
-      this._throwIfNotString(p);
-      return this._lookup(path.dirname(p));
-   };
+    MockFS.prototype._throwIfFSReadOnly = function () {
+        if (this._options.readonly) {
+            throw new Error('EROFS');
+        }
+    };
 
-   MockFS.prototype._mkDirectory = function(parent, p, mode) {
-      this._throwIfFSReadOnly();
-      var dirName = path.basename(p);
-      parent.items[dirName] = {
-         mode: mode || parseInt("0777", 8),
-         ctime: new Date(),
-         atime: new Date(),
-         mtime: new Date(),
-         items: {}
-      };
-   };
+    MockFS.prototype._getFd = function () {
+        var fd = this._fdManager.getFd();
+        this._fds.push(fd);
+        return fd;
+    };
 
-   MockFS.prototype._mkFile = function(target, name, content, mode) {
-      var now = new Date();
-      this._throwIfFSReadOnly();
-      target.items[name] = target.items[name] || {};
-      target.items[name].content = content || '';
-      target.items[name].mode = mode || parseInt('0755', 8);
-      target.items[name].ctime = now;
-      target.items[name].mtime = now;
-      target.items[name].atime = target.items[name].atime || now;
+    MockFS.prototype._releaseFd = function (fd) {
+        this._fdManager.releaseFd(fd);
+        this._fds.splice(this._fds.indexOf(fd), 1);
+    };
 
-      return target.items[name];
-   };
+    MockFS.prototype.hasFd = function (fd) {
+        return this._fds.indexOf(fd) !== -1;
+    };
 
-   MockFS.prototype._toBuffer = function(mockf) {
-      var data = typeof mockf == 'object' && mockf.content || mockf;
-      return Buffer.isBuffer(data) ? data : new Buffer(data);
-   };
+    MockFS.prototype._removeFSItem = function (p) {
+        this._throwIfFSReadOnly();
+        var parent = this._lookupParent(p);
+        delete parent.items[path.basename(p)];
+    };
 
-   MockFS.prototype._isDirectory = function(mocki) {
-      return mocki && typeof mocki.items == 'object' && !('content' in mocki);
-   };
+    MockFS.prototype._getcb = function (args) {
+        for (var i = args.length; i >= 0; i--) {
+            if (typeof args[i] == 'function') {
+                var f = args[i];
+                delete args[i];
+                return f;
+            }
+        }
+        return nop;
+    };
 
-   MockFS.prototype._mkStat = function(item) {
-      return new Stats(item, this);
-   };
+    MockFS.prototype._resolveAndRelate = function (p) {
+        return path.resolve(p).substr(this._path.length);
+    };
 
-   MockFS.prototype.mount = function(p, opts) {
-      if(this._mounted) {
-         throw new Error('EALREADYMOUNED');
-      }
-      // mountpoint is always directory - add trailing path separator
-      p = path.join(path.resolve(p), path.sep);
-      if(mountPoints[p]) {
-         throw new Error("EINUSE");
-      }
-      mountPoints[p] = this;
-      this._path = p;
-      this._mounted = true;
-      this._options = opts || {};
-   };
+    MockFS.prototype._lookup = function (p) {
+        var root = this._spec,
+            pathItem;
 
-   MockFS.prototype.umount = function() {
-      if(this._mounted) {
-         this._fdManager.releaseFd.apply(this._fdManager, this._fds);
-         delete mountPoints[this._path];
-         this._path = null;
-         this._mounted = false;
-      }
-   };
+        this._throwIfNotString(p);
 
-   MockFS.prototype.getMountPoint = function() {
-      return this._path;
-   };
+        p = this._resolveAndRelate(p).split(path.sep);
+        while (p.length) {
+            pathItem = p.shift();
+            if (pathItem) {
+                if (root && root.items && pathItem in root.items) {
+                    root = root.items[pathItem]
+                } else {
+                    throw errNoException('ENOENT', 'lookup');
+                }
+            }
+        }
+        return root;
+    };
 
-   MockFS.mount = function(spec, path, options) {
-      var fs = new MockFS(spec);
-      fs.mount(path, options);
-      return fs;
-   };
+    MockFS.prototype._createBuffer = function (data, encoding) {
+        return Buffer.isBuffer(data) ? data : new Buffer(data, encoding || 'utf8');
+    };
 
-   plugins.forEach(function(pluginName){
-      var plugin = require('.' + path.sep + 'plugins' + path.sep + pluginName);
-      Object.keys(plugin).forEach(function(mtd){
-         MockFS.prototype[mtd] = plugin[mtd];
-      });
-   });
+    MockFS.prototype._lookupParent = function (p) {
+        this._throwIfNotString(p);
+        return this._lookup(path.dirname(p));
+    };
 
-   module.exports = MockFS;
+    MockFS.prototype._mkDirectory = function (parent, p, mode) {
+        this._throwIfFSReadOnly();
+        var dirName = path.basename(p);
+        parent.items[dirName] = {
+            mode: mode || parseInt("0777", 8),
+            ctime: new Date(),
+            atime: new Date(),
+            mtime: new Date(),
+            items: {}
+        };
+    };
+
+    MockFS.prototype._mkFile = function (target, name, content, mode) {
+        var now = new Date();
+        this._throwIfFSReadOnly();
+        target.items[name] = target.items[name] || {};
+        target.items[name].content = content || '';
+        target.items[name].mode = mode || parseInt('0755', 8);
+        target.items[name].ctime = now;
+        target.items[name].mtime = now;
+        target.items[name].atime = target.items[name].atime || now;
+
+        return target.items[name];
+    };
+
+    MockFS.prototype._toBuffer = function (mockf) {
+        var data = typeof mockf == 'object' && mockf.content || mockf;
+        return Buffer.isBuffer(data) ? data : new Buffer(data);
+    };
+
+    MockFS.prototype._isDirectory = function (mocki) {
+        return mocki && typeof mocki.items == 'object' && !('content' in mocki);
+    };
+
+    MockFS.prototype._mkStat = function (item) {
+        return new Stats(item, this);
+    };
+
+    MockFS.prototype.mount = function (p, opts) {
+        if (this._mounted) {
+            throw errNoException('EALREADYMOUNED', 'mount');
+        }
+        // mountpoint is always directory - add trailing path separator
+        p = path.join(path.resolve(p), path.sep);
+        if (mountPoints[p]) {
+            throw errNoException("EINUSE", 'mount');
+        }
+        mountPoints[p] = this;
+        this._path = p;
+        this._mounted = true;
+        this._options = opts || {};
+    };
+
+    MockFS.prototype.umount = function () {
+        if (this._mounted) {
+            this._fdManager.releaseFd.apply(this._fdManager, this._fds);
+            delete mountPoints[this._path];
+            this._path = null;
+            this._mounted = false;
+        }
+    };
+
+    MockFS.prototype.getMountPoint = function () {
+        return this._path;
+    };
+
+    MockFS.mount = function (spec, path, options) {
+        var fs = new MockFS(spec);
+        fs.mount(path, options);
+        return fs;
+    };
+
+    plugins.forEach(function (pluginName) {
+        var plugin = require('.' + path.sep + 'plugins' + path.sep + pluginName);
+        Object.keys(plugin).forEach(function (mtd) {
+            MockFS.prototype[mtd] = plugin[mtd];
+        });
+    });
+
+    module.exports = MockFS;
 
 })();

--- a/lib/mockfs.js
+++ b/lib/mockfs.js
@@ -16,7 +16,7 @@ if (process.platform == 'colony') {
 wrap(fs, mountPoints);
 
 (function () {
-
+    'use strict';
     function MockFS(spec) {
         var now = new Date();
         this._mounted = false;

--- a/lib/plugins/appendfile.js
+++ b/lib/plugins/appendfile.js
@@ -1,28 +1,29 @@
 var path = require('path');
+var errNoException = require('./../common').errNoException;
 
 module.exports = {
-   _appendFileSync: function(p, data, encoding) {
-      var current;
+    _appendFileSync: function (p, data, encoding) {
+        var current;
 
-      try {
-         current = this._readFileSync(p);
-      } catch(e) {
-         if(e.message !== 'ENOENT')
-            throw e;
-      }
+        try {
+            current = this._readFileSync(p);
+        } catch (e) {
+            if (e.message !== 'ENOENT')
+                throw errNoException(e.message, "appendFileSync");
+        }
 
-      data = this._createBuffer(data, encoding);
-      if(current)
-         data = Buffer.concat([current, data]);
-      this._writeFileSync(p, data);
+        data = this._createBuffer(data, encoding);
+        if (current)
+            data = Buffer.concat([current, data]);
+        this._writeFileSync(p, data);
 
-   },
-   _appendFile: function() {
-      var cb = this._getcb(arguments);
-      try {
-         cb(null, this._appendFileSync.apply(this, arguments));
-      } catch(e) {
-         cb(e);
-      }
-   }
+    },
+    _appendFile: function () {
+        var cb = this._getcb(arguments);
+        try {
+            cb(null, this._appendFileSync.apply(this, arguments));
+        } catch (e) {
+            cb(e);
+        }
+    }
 };

--- a/lib/plugins/fd.js
+++ b/lib/plugins/fd.js
@@ -1,6 +1,6 @@
 (function(){
 
-   "use strict";
+   var errNoException = require('./../common').errNoException;
 
    var constants = {
       O_RDONLY: 0x0000,
@@ -59,7 +59,7 @@
          case 'xa+': return O_APPEND | O_CREAT | O_RDWR | O_EXCL;
       }
 
-      throw new Error('EINVAL');
+      throw errNoException('EINVAL','parseFlags');
    }
 
    module.exports = {
@@ -68,7 +68,7 @@
          if(fd > 0 && fd in fdMap) {
             return fdMap[fd];
          } else {
-            throw new Error('EBADF');
+            throw errNoException('EBADF','_getFdOrThrow');
          }
       },
       _fsyncSync: function(fd) {
@@ -89,7 +89,7 @@
                fd.item.content = new Buffer(fd.item.content.toString('base64', 0, len), 'base64');
             }
          } else {
-            throw new Error('EINVAL');
+            throw  errNoException('EINVAL','_truncateSync');
          }
       },
       _truncate:common.wrapSyncCall('_truncateSync'),
@@ -106,11 +106,11 @@
          if(it) {
             // target path exists, is directory and write mode specified
             if(flags !== O_RDONLY && this._isDirectory(it)) {
-               throw new Error('EISDIR');
+               throw errNoException('EISDIR','openSync');
             }
             // file exists, but exclusive creation requested
             if((flags & O_CREAT) && (flags & O_EXCL)) {
-               throw new Error('EEXIST');
+               throw errNoException('EEXIST','openSync');
             }
 
             // 'it' is a string, or an object, but has no 'content' and 'items' in (it is a Buffer)
@@ -135,10 +135,10 @@
                   it = this._mkFile(parent, name, new Buffer(""), mode);
                } else {
                   // file is not exists and no creation flag
-                  throw new Error('ENOENT');
+                  throw errNoException('ENOENT','openSync');
                }
             } else {
-               throw new Error('ENOTDIR');
+               throw errNoException('ENOTDIR','openSync');
             }
 
          }
@@ -162,7 +162,7 @@
 
          fd = this._getFdOrThrow(fd);
          if(fd.flags === O_RDONLY) {
-            throw new Error('EACCESS');
+            throw errNoException('EACCESS','writeSync');
          }
          offset = offset || 0;
          length = length || 0;
@@ -201,10 +201,10 @@
 
          fd = this._getFdOrThrow(fd);
          if(fd.flags & O_WRONLY) {
-            throw new Error('EBADF');
+            throw errNoException('EBADF','readSync');
          }
          if(this._isDirectory(fd.item)) {
-            throw new Error('EISDIR');
+            throw errNoException('EISDIR','readSync');
          }
          offset = offset || 0;
          length = length || 0;

--- a/lib/plugins/fd.js
+++ b/lib/plugins/fd.js
@@ -1,5 +1,5 @@
 (function(){
-
+   'use strict';
    var errNoException = require('./../common').errNoException;
 
    var constants = {

--- a/lib/plugins/mkdir.js
+++ b/lib/plugins/mkdir.js
@@ -1,23 +1,23 @@
 var path = require('path');
-
+var errNoException = require('./../common').errNoException;
 module.exports = {
    _mkdir: function() {
       var cb = this._getcb(arguments);
       try {
          cb(null, this._mkdirSync.apply(this, arguments));
       } catch (e) {
-         cb(e);
+         cb(errNoException(e.message,'mkdir') );
       }
    },
    _mkdirSync: function(p, mode) {
       if(this._existsSync(p)) {
-         throw new Error('EEXIST');
+         throw errNoException('EEXIST','mkdirSync');
       } else {
          var parent = this._lookupParent(p);
          if(this._isDirectory(parent)) {
             this._mkDirectory(parent, p, mode);
          } else {
-            throw new Error('ENOTDIR');
+            throw errNoException('ENOTDIR','mkdirSync');
          }
       }
    }

--- a/lib/plugins/readdir.js
+++ b/lib/plugins/readdir.js
@@ -1,9 +1,12 @@
+var errNoException = require('./../common').errNoException;
+
 module.exports = {
    _readdir: function() {
       var cb = this._getcb(arguments);
       try {
          cb(null, this._readdirSync.apply(this, arguments));
       } catch(e) {
+          // e is already converted in sync function
          cb(e);
       }
    },
@@ -12,6 +15,6 @@ module.exports = {
       if(this._isDirectory(root)) {
          return Object.keys(root.items);
       } else
-         throw new Error("ENOTDIR");
+         throw errNoException("ENOTDIR",'readdir');
    }
 };

--- a/lib/plugins/readfile.js
+++ b/lib/plugins/readfile.js
@@ -1,3 +1,5 @@
+var errNoException = require('./../common').errNoException;
+
 module.exports = {
 
    _readFile: function() {
@@ -5,6 +7,7 @@ module.exports = {
       try {
          cb(null, this._readFileSync.apply(this, arguments));
       } catch (e) {
+        //e is already converted in sync function
          cb(e);
       }
    },
@@ -15,6 +18,6 @@ module.exports = {
          buf = this._toBuffer(f);
          return encoding ? buf.toString(encoding) : buf;
       } else
-         throw new Error('EISDIR');
+         throw errNoException('EISDIR','readFileSync');
    }
 };

--- a/lib/plugins/rename.js
+++ b/lib/plugins/rename.js
@@ -1,4 +1,5 @@
 var path = require('path');
+var errNoException = require('./../common').errNoException;
 
 module.exports = {
    _renameSync: function(src, dst) {
@@ -7,18 +8,18 @@ module.exports = {
 
       var lastComp = path.basename(src);
       if(lastComp === '.' || lastComp === '..') {
-         throw new Error('EINVAL');
+         throw errNoException('EINVAL','renameSync');
       }
 
       src = path.resolve(src);
       dst = path.resolve(dst);
 
       if(dst.indexOf(this.getMountPoint()) !== 0) {
-         throw new Error('EXDEV');
+          throw errNoException('EXDEV','renameSync');
       }
 
       if(dst.indexOf(path.join(src, path.sep)) === 0) {
-         throw new Error('EINVAL');
+            throw errNoException('EINVAL','renameSync');
       }
 
       iSrc = this._lookup(src);
@@ -32,19 +33,19 @@ module.exports = {
          if(this._isDirectory(iSrc)) {
             if(!this._isDirectory(iDst)) {
                // but destination isn't
-               throw new Error('ENOTDIR');
+               throw errNoException('ENOTDIR','renameSync');
             } else {
                // destination is direcotry
                if(Object.keys(iDst.items).length > 0) {
                   // but isn't empty
-                  throw new Error('ENOTEMPTY');
+                   throw errNoException('ENOTEMPTY','renameSync');
                }
             }
          } else {
             // source is a file
             if(this._isDirectory(iDst)) {
                // but destination is a directory
-               throw new Error('EISDIR');
+               throw errNoException('EISDIR','renameSync');
             }
          }
       }
@@ -66,6 +67,7 @@ module.exports = {
          this._renameSync.apply(this, arguments);
          cb(null);
       } catch(e) {
+          // e is alredy converted to exception with errorcode
          cb(e);
       }
    }

--- a/lib/plugins/rmdir.js
+++ b/lib/plugins/rmdir.js
@@ -1,13 +1,14 @@
 var path = require('path');
+var errNoException = require('./../common').errNoException;
 
 module.exports = {
    _rmdirSync: function(p) {
       var target = this._lookup(p);
       if(!this._isDirectory(target)) {
-         throw new Error('ENOTDIR');
+         throw errNoException('ENOTDIR','rmdirSync');
       }
       if(Object.keys(target.items).length > 0) {
-         throw new Error('ENOTEMPTY');
+         throw errNoException('ENOTEMPTY','rmdirSync');
       }
       this._removeFSItem(p);
    },

--- a/lib/plugins/stat.js
+++ b/lib/plugins/stat.js
@@ -1,5 +1,5 @@
 (function(){
-
+   'use strict';
    module.exports = {
       _statSync: function(p) {
          return this._mkStat(this._lookup(p));

--- a/lib/plugins/stat.js
+++ b/lib/plugins/stat.js
@@ -1,7 +1,5 @@
 (function(){
 
-   "use strict";
-
    module.exports = {
       _statSync: function(p) {
          return this._mkStat(this._lookup(p));

--- a/lib/plugins/unlink.js
+++ b/lib/plugins/unlink.js
@@ -1,10 +1,11 @@
 var path = require('path');
+var errNoException = require('./../common').errNoException;
 
 module.exports = {
    _unlinkSync: function(p) {
       var target = this._lookup(p);
       if(this._isDirectory(target)) {
-         throw new Error('EPERM');
+         throw errNoException('EPERM','unlinkSync');
       }
       this._removeFSItem(p);
    },

--- a/lib/plugins/writefile.js
+++ b/lib/plugins/writefile.js
@@ -1,30 +1,32 @@
 var path = require('path');
+var errNoException = require('./../common').errNoException;
 
 module.exports = {
-   _writeFileSync : function(p, data, encoding) {
-      var target, parent;
-      try {
-         target = this._lookup(p);
-      } catch (e) {
-         // if file is not exists, will create it
-         if(e.message !== 'ENOENT')
-            throw e;
-      }
-      if(target && this._isDirectory(target)) {
-         throw new Error('EISDIR');
-      }
-      parent = this._lookupParent(p);
-      if(this._isDirectory(parent)) {
-         this._mkFile(parent, path.basename(p), this._createBuffer(data, encoding));
-      } else
-         throw new Error('ENOTDIR');
-   },
-   _writeFile : function() {
-      var cb = this._getcb(arguments);
-      try {
-         cb(null, this._writeFileSync.apply(this, arguments));
-      } catch(e) {
-         cb(e);
-      }
-   }
+    _writeFileSync: function (p, data, encoding) {
+        var target, parent;
+        try {
+            target = this._lookup(p);
+        } catch (e) {
+            // if file is not exists, will create it
+            if (e.message !== 'ENOENT') {
+                throw errNoException(e.message, 'writeFileSync');
+            }
+        }
+        if (target && this._isDirectory(target)) {
+            throw errNoException('EISDIR', 'writeFileSync');
+        }
+        parent = this._lookupParent(p);
+        if (this._isDirectory(parent)) {
+            this._mkFile(parent, path.basename(p), this._createBuffer(data, encoding));
+        } else
+            throw errNoException('ENOTDIR', 'writeFileSync');
+    },
+    _writeFile: function () {
+        var cb = this._getcb(arguments);
+        try {
+            cb(null, this._writeFileSync.apply(this, arguments));
+        } catch (e) {
+            cb(e);
+        }
+    }
 };

--- a/lib/stat.js
+++ b/lib/stat.js
@@ -1,7 +1,5 @@
 (function(){
 
-   "use strict";
-
    function retFalse() { return false; }
    function retTrue() { return true; }
    function mkTime(v, ref) {

--- a/lib/wrapfs.js
+++ b/lib/wrapfs.js
@@ -1,7 +1,7 @@
 var path = require('path');
 
 (function(){
-
+   'use strict';
    // path - with or without trailing slash
    function getFS(p, mnt) {
       var parts, toCheck;

--- a/lib/wrapfs.js
+++ b/lib/wrapfs.js
@@ -2,8 +2,6 @@ var path = require('path');
 
 (function(){
 
-   "use strict";
-
    // path - with or without trailing slash
    function getFS(p, mnt) {
       var parts, toCheck;

--- a/package.json
+++ b/package.json
@@ -1,35 +1,40 @@
 {
-   "name": "mockfs",
-   "description": "Mocking FS module implementation for testing purpouses",
-   "version": "0.1.5",
-   "author": "Oleg Elifantiev <oleg@elifantiev.ru>",
-   "contributors": [],
-   "keywords": [
-      "fs",
-      "file system",
-      "mock",
-      "testing"
-   ],
-   "bugs": {
-      "url": "https://github.com/Olegas/mockfs/issues"
-   },
-   "repository": {
-      "type": "git",
-      "url": "https://github.com/Olegas/mockfs.git"
-   },
-   "devDependencies": {
-      "mocha": "",
-      "coveralls": "",
-      "istanbul": "",
-      "mocha-istanbul": "",
-      "assert": ""
-   },
-   "scripts": {
-      "instrument": "node ./node_modules/.bin/istanbul instrument --output lib-cov --no-compact --variable global.__coverage__ lib",
-      "test-cov": "npm run-script instrument && COVER=mockfs ISTANBUL_REPORTERS=lcovonly node ./node_modules/.bin/mocha -R mocha-istanbul",
-      "test": "node ./node_modules/mocha/bin/mocha -R spec"
-   },
-   "engines": {
-      "node": ">=0.8"
-   }
+  "name": "mockfs",
+  "description": "Mocking FS module implementation for testing purpouses",
+  "version": "0.1.5",
+  "author": "Oleg Elifantiev <oleg@elifantiev.ru>",
+  "contributors": [],
+  "keywords": [
+    "fs",
+    "file system",
+    "mock",
+    "testing"
+  ],
+  "bugs": {
+    "url": "https://github.com/Olegas/mockfs/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Olegas/mockfs.git"
+  },
+  "devDependencies": {
+    "assert": "",
+    "coveralls": "",
+    "istanbul": "",
+    "mkdirp": "^0.5.0",
+    "mocha": "",
+    "mocha-istanbul": ""
+  },
+  "scripts": {
+    "instrument": "node ./node_modules/.bin/istanbul instrument --output lib-cov --no-compact --variable global.__coverage__ lib",
+    "test-cov": "npm run-script instrument && COVER=mockfs ISTANBUL_REPORTERS=lcovonly node ./node_modules/.bin/mocha -R mocha-istanbul",
+    "test": "node ./node_modules/mocha/bin/mocha -R spec"
+  },
+  "engines": {
+    "node": ">=0.8"
+  },
+  "dependencies": {
+    "errors": "^0.2.0",
+    "util": "^0.10.3"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "assert": "",
     "coveralls": "",
     "istanbul": "",
-    "mkdirp": "^0.5.0",
+    "mkdirp": "",
     "mocha": "",
     "mocha-istanbul": ""
   },
@@ -34,7 +34,5 @@
     "node": ">=0.8"
   },
   "dependencies": {
-    "errors": "^0.2.0",
-    "util": "^0.10.3"
   }
 }

--- a/test/test-appendFile.js
+++ b/test/test-appendFile.js
@@ -3,6 +3,7 @@ var mfs = require('../'),
    fs = require('fs'),
    mounted;
 
+
 describe("appendFile", function(){
 
    before(function(){
@@ -50,6 +51,16 @@ describe("appendFile", function(){
       assert.throws(function(){
          fs.appendFileSync('/mnt/mock/nonexist/file', 'willthrow');
       }, /ENOENT/);
+   });
+
+    it("make sure the throwed ENOENT when writing to file in a nonexistent directory is mentioned in the exception.code", function(){
+     try {
+        fs.appendFileSync('/mnt/mock/nonexist/file', 'willthrow');
+      }
+      catch (err){
+          assert.equal(err.code,'ENOENT');
+      }
+
    });
 
    it("throws ENOTDIR if trying to write to file in a non-directory", function(){

--- a/test/test-mkdirp.js
+++ b/test/test-mkdirp.js
@@ -1,0 +1,63 @@
+var mfs = require('../'),
+   assert = require('assert'),
+   mkdirp = require('mkdirp'),
+   fs = require('fs'),
+   mounted;
+
+/**
+    mkdirp is a utility function for creating directory paths
+    mkdirp expects to have error codes on exceptions thrown by the file system,
+    like the normal node fs does. These tests are included to make sure mkdirp
+    works as expected on mockfs.
+*/
+
+describe("mkdirp", function(){
+
+   before(function(){
+      mounted = mfs.mount({
+         items: {
+            'file': '',
+            'adir': {
+               items: {}
+            }
+         }
+      }, '/mnt/mock');
+
+   });
+
+   it("can create directories in already existing ones", function(done){
+
+      assert.equal(false, fs.existsSync('/mnt/mock/adir/some/other'));
+      mkdirp.sync('/mnt/mock/adir/some/other');
+      assert.equal(true, fs.existsSync('/mnt/mock/adir/some/other'));
+
+      mkdirp('/mnt/mock/async/example', function(e) {
+         assert.equal(null, e);
+         assert.equal(true, fs.existsSync('/mnt/mock/async/example'));
+         done();
+      });
+
+   });
+
+   it("throws ENOTDIR when parent is a file", function(){
+      assert.throws(function(){
+         mkdirp.sync('/mnt/mock/file/some');
+      }, /ENOTDIR/);
+   });
+
+   it("creates directory even if parent does not exists", function(){
+      assert.equal(false, fs.existsSync('/mnt/mock/nonexist/some'));
+      mkdirp.sync('/mnt/mock/nonexist/some');
+      assert.equal(true, fs.existsSync('/mnt/mock/nonexist/some'));
+   });
+
+   it("Ignores if directory already exists", function(){
+       assert.equal(true, fs.existsSync('/mnt/mock/adir'));
+       mkdirp.sync('/mnt/mock/adir');
+       assert.equal(true, fs.existsSync('/mnt/mock/adir'));
+   });
+
+   after(function(){
+      mounted.umount();
+   });
+});


### PR DESCRIPTION
Using mockfs I found that mkdirp did not on the virtual filesystem. The problem was that mkdirp depended on the .code the node fs add to the errnoExceptions it creates. In lib/common.js I added a function that resembles those used by node fs, to create an Error() object, and add a little extra information on them (code, errno, syscall). Hopefully this will make mockfs and other third party tools depending on this specific file system behaviour, play well together. I know it is a rather big change, but it wraps most places where an exception was thrown.
